### PR TITLE
Reference counted values

### DIFF
--- a/samples/args.lang
+++ b/samples/args.lang
@@ -1,0 +1,2 @@
+run = [a] { println(a); }
+run(1, 2)

--- a/samples/echo.lang
+++ b/samples/echo.lang
@@ -1,0 +1,1 @@
+[arg] { println(arg); } ("Hello, world!")

--- a/samples/vars.lang
+++ b/samples/vars.lang
@@ -1,0 +1,6 @@
+a = 1
+run = [arg] { }
+run(a)
+
+run2 = [arg] { println(arg); }
+run2(a);

--- a/src/interpret/environment.cpp
+++ b/src/interpret/environment.cpp
@@ -12,34 +12,21 @@ Environment::Environment(ASTNode *root) {
 }
 
 Environment::~Environment() {
-    while (!frames.empty()) {
-        for (auto &entry : frames.top()) {
-            delete entry.second;
-        }
-        frames.pop();
-    }
-
-    for (auto &entry : effectFrames) {
-        while (!entry.second.empty()) {
-            delete entry.second.top().second;
-            entry.second.pop();
-        }
-    }
 }
 
-int Environment::invoke(const string &name, Value *params, Value *&value) {
+int Environment::invoke(const string &name, Value params, Value &value) {
     if (!frames.size()) {
         cerr << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
         return -1;
     }
 
-    Value *fn = nullptr;
+    Value fn{nullptr};
     int retval = get(name, fn);
     if (retval || !fn) {
         return retval ? retval : -1;
     }
 
-    if (fn->getType() != ValueType::FUNCTION) {
+    if (fn.getType() != ValueType::FUNCTION) {
         cerr << "Name \"" << name << "\" is not callable." << endl;
         return -1;
     }
@@ -47,20 +34,20 @@ int Environment::invoke(const string &name, Value *params, Value *&value) {
     return invoke(fn, params, value);
 }
 
-int Environment::invoke(Value *fn, Value *args, Value *&value) {
-    if (!args && fn->getParams().size()) {
-        cerr << "Expected " << fn->getParams().size() << " arguments but got 0." << endl;
+int Environment::invoke(Value fn, Value args, Value &value) {
+    if (!args && fn.getParams().size()) {
+        cerr << "Expected " << fn.getParams().size() << " arguments but got 0." << endl;
         return -1;
     }
 
-    frameIDs.emplace(fn->getFn());
+    frameIDs.emplace(fn.getFn());
     frames.emplace();
 
     if (args) {
-        auto &paramNames = fn->getParams();
-        auto &argValues = args->getValues();
+        auto &paramNames = fn.getParams();
+        auto &argValues = args.getValues();
         if (
-            args->getType() == ValueType::TUPLE
+            args.getType() == ValueType::TUPLE
             && paramNames.size() != 1
         ) {
             if (paramNames.size() != argValues.size()) {
@@ -68,7 +55,6 @@ int Environment::invoke(Value *fn, Value *args, Value *&value) {
                 return -1;
             }
             for (size_t i = 0; i < paramNames.size(); ++i) {
-                argValues[i]->markAutoDelete();
                 frames.top()[paramNames[i]] = argValues[i];
             }
         } else {
@@ -77,26 +63,22 @@ int Environment::invoke(Value *fn, Value *args, Value *&value) {
                 return -1;
             }
 
-            args->markAutoDelete();
             frames.top()[paramNames[0]] = args;
         }
     }
 
-    value = fn->getFn()->interpret(*this, 1);
+    value = fn.getFn()->interpret(*this, 1);
     if (!value) {
-        value = new Value{0};
+        value = 0;
     }
 
-    for (auto &val : frames.top()) {
-        delete val.second;
-    }
     frames.pop();
     frameIDs.pop();
 
     return 0;
 }
 
-int Environment::get(const string &name, Value *&value) const {
+int Environment::get(const string &name, Value &value) const {
     if (!frames.size()) {
         cerr << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
         return -1;
@@ -121,30 +103,22 @@ int Environment::get(const string &name, Value *&value) const {
     return 0;
 }
 
-int Environment::set(const string &name, Value *value) {
+int Environment::set(const string &name, Value value) {
     if (!frames.size()) {
         cerr << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
         return -1;
     }
 
     auto &currentFrame = frames.top();
-    auto entry = currentFrame.find(name);
-    if (entry != currentFrame.end()) {
-        delete entry->second;
-    }
-    value->markAutoDelete();
     currentFrame[name] = value;
     return 0;
 }
 
-int Environment::setEffect(const string &name, Value *value) {
+int Environment::setEffect(const string &name, Value value) {
     if (!frameIDs.size()) {
         cerr << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
         return -1;
     }
-    
-    // Only do this once we're sure the value will be added to a frame.
-    value->markAutoDelete();
 
     auto *currentFrameID = frameIDs.top();
     auto nameFrames = effectFrames.find(name);
@@ -152,7 +126,6 @@ int Environment::setEffect(const string &name, Value *value) {
         nameFrames != effectFrames.end()
         && !nameFrames->second.empty()
         && nameFrames->second.top().first == currentFrameID) {
-        delete nameFrames->second.top().second;
         nameFrames->second.top().second = value;
         return 0;
     }

--- a/src/interpret/environment.hpp
+++ b/src/interpret/environment.hpp
@@ -7,16 +7,16 @@
 #include "./value.hpp"
 
 class Environment {
-        std::stack<std::unordered_map<std::string, Value *>> frames;
+        std::stack<std::unordered_map<std::string, Value>> frames;
         std::stack<const ASTNode *> frameIDs;
-        std::unordered_map<std::string, std::stack<std::pair<const ASTNode *, Value *>>> effectFrames;
+        std::unordered_map<std::string, std::stack<std::pair<const ASTNode *, Value>>> effectFrames;
     public:
         Environment(ASTNode *root);
         ~Environment();
 
-        int invoke(const std::string &name, Value *args, Value *&value);
-        int invoke(Value *fn, Value *args, Value *&value);
-        int get(const std::string &name, Value *&value) const;
-        int set(const std::string &name, Value *value);
-        int setEffect(const std::string &name, Value *value);
+        int invoke(const std::string &name, Value args, Value &value);
+        int invoke(Value fn, Value args, Value &value);
+        int get(const std::string &name, Value &value) const;
+        int set(const std::string &name, Value value);
+        int setEffect(const std::string &name, Value value);
 };

--- a/src/interpret/interpreter.cpp
+++ b/src/interpret/interpreter.cpp
@@ -23,11 +23,14 @@ int interpret(ASTNode *ast) {
     env.setEffect("println", println->interpret(env));
 
     Value result = ast->interpret(env);
-    if (result) {
-        cout << result.str() << endl;
-    } else {
-        cerr << "Returned an error" << endl;
-        return -1;
+    if (!result.isEmpty()) {
+        if (result) {
+            cout << result.str() << endl;
+        } else {
+            cerr << "Returned an error" << endl;
+            cerr << result.str() << endl;
+            return -1;
+        }
     }
 
     return 0;

--- a/src/interpret/interpreter.cpp
+++ b/src/interpret/interpreter.cpp
@@ -22,20 +22,12 @@ int interpret(ASTNode *ast) {
     env.setEffect("print", print->interpret(env));
     env.setEffect("println", println->interpret(env));
 
-    Value *result = ast->interpret(env);
+    Value result = ast->interpret(env);
     if (result) {
-        if (*result) {
-            cout << result->str() << endl;
-            if (!result->isAutoDelete()) {
-                delete result;
-            }
-        } else {
-            cerr << "Returned an error" << endl;
-            if (!result->isAutoDelete()) {
-                delete result;
-            }
-            return -1;
-        }
+        cout << result.str() << endl;
+    } else {
+        cerr << "Returned an error" << endl;
+        return -1;
     }
 
     return 0;

--- a/src/interpret/value.hpp
+++ b/src/interpret/value.hpp
@@ -27,7 +27,11 @@ class Value {
             Data(double num) : num{num}, type{ValueType::NUMBER} {}
             Data(std::string strsym, bool sym) : strsym{strsym}, type{sym ? ValueType::SYMBOL : ValueType::STRING} {}
             Data(const ASTNode *fn, const std::vector<std::string> &params) : fn{fn}, fnParams{params}, type{ValueType::FUNCTION} {}
-            Data(const std::vector<Value> &values) : values{values}, type{ValueType::TUPLE} {}
+
+            // Note: ()-style rather than {}-style initialization is required
+            // in order to avoid implicit conversions.
+            Data(const std::vector<Value> &values)
+                : values(values), type{ValueType::TUPLE} {}
         };
 
         Data *data;

--- a/src/interpret/value.hpp
+++ b/src/interpret/value.hpp
@@ -44,12 +44,10 @@ class Value {
             }
         }
         Value(const Value &other) : data{other.data} {
-            ++data->refCount;
+            if (data) ++data->refCount;
         }
         Value &operator=(const Value &other) {
-            if (!--data->refCount) {
-                delete data;
-            }
+            if (data && !--data->refCount) delete data;
             data = other.data;
             ++data->refCount;
 
@@ -57,9 +55,7 @@ class Value {
         }
 
         ~Value() {
-            if (!--data->refCount) {
-                delete data;
-            }
+            if (data && !--data->refCount) delete data;
         }
 
         ValueType getType() {
@@ -74,6 +70,10 @@ class Value {
                 return data->strsym.size() == 0;
             }
             return false;
+        }
+
+        bool isEmpty() const {
+            return !data;
         }
 
         operator bool() const {

--- a/src/interpret/value.hpp
+++ b/src/interpret/value.hpp
@@ -90,8 +90,11 @@ class Value {
             }
             if (data->type == ValueType::TUPLE) {
                 std::string output;
-                for (auto value : data->values) {
-                    output += value.str() + ",";
+                for (auto &value : data->values) {
+                    if (&value != &data->values[0]) {
+                        output += ",";
+                    }
+                    output += value.str();
                 }
                 return output;
             }

--- a/src/interpret/value.hpp
+++ b/src/interpret/value.hpp
@@ -39,9 +39,7 @@ class Value {
         Value(const std::vector<Value> &values) : data{new Data{values}} {}
 
         explicit Value(Value *other) : data{other ? other->data : nullptr} {
-            if (data) {
-                ++data->refCount;
-            }
+            if (data) ++data->refCount;
         }
         Value(const Value &other) : data{other.data} {
             if (data) ++data->refCount;
@@ -49,8 +47,7 @@ class Value {
         Value &operator=(const Value &other) {
             if (data && !--data->refCount) delete data;
             data = other.data;
-            ++data->refCount;
-
+            if (data) ++data->refCount;
             return *this;
         }
 

--- a/src/simplify/ast_node.cpp
+++ b/src/simplify/ast_node.cpp
@@ -36,20 +36,15 @@ NonterminalType ASTNode::getNonterminal() const {
 bool ASTNode::isTerminal() const { return holdsTerminal; }
 
 // Default behaviour.
-Value *ASTNode::interpret(Environment &env, short) const {
-    Value *result = nullptr;
+Value ASTNode::interpret(Environment &env, short) const {
+    Value result{nullptr};
     for (auto *child : children) {
         if (child) {
-            Value *next = child->interpret(env);
-            if (next) {
-                if (!*next) {
-                    return next;
-                }
-                if (result && !result->isAutoDelete()) {
-                    delete result;
-                }
-                result = next;
+            Value next = child->interpret(env);
+            if (!next) {
+                return {};
             }
+            result = next;
         }
     }
 

--- a/src/simplify/ast_node.cpp
+++ b/src/simplify/ast_node.cpp
@@ -41,10 +41,12 @@ Value ASTNode::interpret(Environment &env, short) const {
     for (auto *child : children) {
         if (child) {
             Value next = child->interpret(env);
-            if (!next) {
-                return {};
+            if (!next.isEmpty()) {
+                if (!next) {
+                    return next;
+                }
+                result = next;
             }
-            result = next;
         }
     }
 

--- a/src/simplify/ast_node.hpp
+++ b/src/simplify/ast_node.hpp
@@ -22,7 +22,7 @@ struct ASTNode {
         NonterminalType getNonterminal() const;
         bool isTerminal() const;
 
-        virtual Value *interpret(Environment &env, short caller = 0) const;
+        virtual Value interpret(Environment &env, short caller = 0) const;
 
         friend std::ostream &operator<<(std::ostream &, const ASTNode &);
     protected:

--- a/src/simplify/nodes/binary_operator.hpp
+++ b/src/simplify/nodes/binary_operator.hpp
@@ -8,52 +8,46 @@
 struct BinaryOperatorNode : public ASTNode {
     BinaryOperatorNode() : ASTNode{NonterminalType::expr} {}
 
-    virtual Value *interpret(Environment &env, short caller = 0) const {
+    virtual Value interpret(Environment &env, short caller = 0) const {
         if (children.size() != 3) {
             cerr << children.size() << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
-            return new Value;
+            return {};
         }
 
-        Value *result;
-        Value *leftValue = children[0]->interpret(env);
-        Value *rightValue = children[2]->interpret(env);
+        Value result{nullptr};
+        Value leftValue = children[0]->interpret(env);
+        Value rightValue = children[2]->interpret(env);
         switch (children[1]->getTerminal()) {
             case TokenType::PLUS:
-                result = *leftValue + *rightValue;
+                result = leftValue + rightValue;
                 break;
             case TokenType::MINUS:
-                result = *leftValue - *rightValue;
+                result = leftValue - rightValue;
                 break;
             case TokenType::STAR:
-                result = *leftValue * *rightValue;
+                result = leftValue * rightValue;
                 break;
             case TokenType::SLASH:
-                result = *leftValue / *rightValue;
+                result = leftValue / rightValue;
                 break;
             case TokenType::STARSTAR:
-                result = *leftValue ^ *rightValue;
+                result = leftValue ^ rightValue;
                 break;
             case TokenType::PERCENT:
-                result = *leftValue % *rightValue;
+                result = leftValue % rightValue;
                 break;
             case TokenType::EQUALS:
                 env.set(children[0]->getLexeme(), rightValue);
                 // Need to keep previous value around, so short circuit.
-                delete leftValue;
                 return rightValue;
             case TokenType::EQSIGNAL:
                 env.setEffect(children[0]->getLexeme(), rightValue);
                 // Need to keep previous value around, so short circuit.
-                delete leftValue;
                 return rightValue;
             default:
                 cerr << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
-                delete leftValue;
-                delete rightValue;
-                return new Value;
+                return {};
         }
-        delete leftValue;
-        delete rightValue;
         return result;
     }
 };

--- a/src/simplify/nodes/decllist.hpp
+++ b/src/simplify/nodes/decllist.hpp
@@ -7,11 +7,11 @@
 
 struct DeclListNode : public ASTNode {
     DeclListNode() : ASTNode{NonterminalType::decllist} {}
-    virtual Value *interpret(Environment &env, short caller = 0) const override {
+    virtual Value interpret(Environment &env, short caller = 0) const override {
         std::vector<std::string> values;
         for (size_t i = 0; i < children.size(); i += 2) {
             values.emplace_back(children[i]->getLexeme());
         }
-        return new Value{this, values};
+        return {this, values};
     }
 };

--- a/src/simplify/nodes/exprpar.hpp
+++ b/src/simplify/nodes/exprpar.hpp
@@ -7,15 +7,12 @@
 
 struct ExprParNode : public ASTNode {
     ExprParNode() : ASTNode{NonterminalType::exprpar} {}
-    virtual Value *interpret(Environment &env, short caller = 0) const override {
-        Value *last = nullptr;
-        Value *cur = nullptr;
+    virtual Value interpret(Environment &env, short caller = 0) const override {
+        Value last{nullptr};
+        Value cur{nullptr};
         for (size_t i = 1; i < children.size(); i += 3) {
             cur = children[i]->interpret(env);
-            if (cur->isFalsy()) {
-                if (last && !last->isAutoDelete()) {
-                    delete last;
-                }
+            if (cur.isFalsy()) {
                 return cur;
             }
             last = cur;

--- a/src/simplify/nodes/function.hpp
+++ b/src/simplify/nodes/function.hpp
@@ -4,7 +4,7 @@
 
 struct FunctionNode : public ASTNode {
     FunctionNode() : ASTNode{NonterminalType::fn} {}
-    virtual Value *interpret(Environment &env, short caller = 0) const {
+    virtual Value interpret(Environment &env, short caller = 0) const {
         ASTNode *procChild = nullptr;
         if (children.size() == 3) {
             procChild = children[1];
@@ -18,19 +18,18 @@ struct FunctionNode : public ASTNode {
             if (caller) {
                 return procChild->interpret(env);
             }
-            Value *params = nullptr;
-            Value *result;
+            Value params{nullptr};
+            Value result{nullptr};
             if (children.size() == 6) {
                 params = children[1]->interpret(env);
-                result = new Value{procChild, params->getParams()};
-                delete params;
+                result = {procChild, params.getParams()};
             } else {
-                result = new Value{procChild, {}};
+                result = {procChild, {}};
             }
             return result;
         }
 
         cerr << "Uh-oh! An internal error occurred while interpreting your program. This is probably a bug..." << endl;
-        return new Value;
+        return {};
     }
 };

--- a/src/simplify/nodes/function_call.hpp
+++ b/src/simplify/nodes/function_call.hpp
@@ -7,9 +7,9 @@
 struct FunctionCallNode : public ASTNode {
     FunctionCallNode() : ASTNode{NonterminalType::fncall} {}
 
-    virtual Value *interpret(Environment &env, short caller = 0) const {
-        Value *value = nullptr;
-        Value *args = nullptr;
+    virtual Value interpret(Environment &env, short caller = 0) const {
+        Value value{nullptr};
+        Value args{nullptr};
         if (children.size() == 4) {
             // Parameters provided.
             args = children[2]->interpret(env);
@@ -22,10 +22,9 @@ struct FunctionCallNode : public ASTNode {
             retval = env.invoke(children[0]->interpret(env), args, value);
         }
 
-        if (retval || !value || !*value) {
+        if (retval || !value) {
             // This is probably not a bug.
-            delete value;
-            return new Value;
+            return {};
         }
         return value;
     }

--- a/src/simplify/nodes/number.hpp
+++ b/src/simplify/nodes/number.hpp
@@ -12,8 +12,8 @@ struct NumberNode : public ASTNode {
         }*/
         NumberNode(const std::string &lexeme) : ASTNode{TokenType::NUM, lexeme}, value{stod(lexeme, nullptr)} {}
 
-        virtual Value *interpret(Environment &env, short caller = 0) const {
-            return new Value{value};
+        virtual Value interpret(Environment &env, short caller = 0) const {
+            return value;
         }
     private:
         double value;

--- a/src/simplify/nodes/print.hpp
+++ b/src/simplify/nodes/print.hpp
@@ -6,14 +6,13 @@
 
 struct PrintNode : public ASTNode {
         PrintNode(bool newline = false) : ASTNode{NonterminalType::fn}, newline{newline} {}
-        virtual Value *interpret(Environment &env, short caller = 0) const {
+        virtual Value interpret(Environment &env, short caller = 0) const {
             if (!caller) {
-                return new Value{this, {"arg"}};
-                return new Value{this, {}};
+                return {this, {"arg"}};
             }
-            Value *value;
+            Value value;
             int retval = env.get("arg", value);
-            if (retval || !*value) {
+            if (retval || !value) {
                 if (newline) {
                     std::cout << std::endl;
                 } else {
@@ -21,12 +20,12 @@ struct PrintNode : public ASTNode {
                 }
             } else {
                 if (newline) {
-                    std::cout << value->str() << std::endl;
+                    std::cout << value.str() << std::endl;
                 } else {
-                    std::cout << value->str() << std::flush;
+                    std::cout << value.str() << std::flush;
                 }
             }
-            return new Value{0};
+            return 0;
         }
     private:
         bool newline;

--- a/src/simplify/nodes/string.hpp
+++ b/src/simplify/nodes/string.hpp
@@ -24,7 +24,7 @@ struct StringNode : public ASTNode {
         replaceString(this->lexeme, "\\\"", "\"");
     }
 
-    virtual Value *interpret(Environment &env, short caller = 0) const {
-        return new Value{lexeme};
+    virtual Value interpret(Environment &env, short caller = 0) const {
+        return lexeme;
     }
 };

--- a/src/simplify/nodes/tuple.hpp
+++ b/src/simplify/nodes/tuple.hpp
@@ -6,11 +6,11 @@
 
 struct TupleNode : public ASTNode {
     TupleNode() : ASTNode{NonterminalType::exprcat3} {}
-    virtual Value *interpret(Environment &env, short caller = 0) const override {
-        std::vector<Value *> values;
+    virtual Value interpret(Environment &env, short caller = 0) const override {
+        std::vector<Value> values;
         for (size_t i = 0; i < children.size(); i += 2) {
             values.emplace_back(children[i]->interpret(env));
         }
-        return new Value{values};
+        return values;
     }
 };

--- a/src/simplify/nodes/usage.hpp
+++ b/src/simplify/nodes/usage.hpp
@@ -7,11 +7,11 @@
 struct UsageNode : public ASTNode {
     UsageNode(const std::string &name) : ASTNode{TokenType::ID, name} {}
 
-    virtual Value *interpret(Environment &env, short caller = 0) const {
-        Value *value;
+    virtual Value interpret(Environment &env, short caller = 0) const {
+        Value value{nullptr};
         int result = env.get(lexeme, value);
-        if (result || !value || !*value) {
-            return new Value;
+        if (result || !value) {
+            return {};
         }
         return value;
     }


### PR DESCRIPTION
Make all values in the language reference counted, rather than manually tracking allocations and deallocations. This is safer and probably still pretty fast.